### PR TITLE
Fix missing dialog on invalid export template archive file

### DIFF
--- a/editor/export/export_template_manager.cpp
+++ b/editor/export/export_template_manager.cpp
@@ -1104,7 +1104,7 @@ ExportTemplateManager::ExportTemplateManager() {
 	install_file_dialog->set_file_mode(FileDialog::FILE_MODE_OPEN_FILE);
 	install_file_dialog->set_current_dir(EDITOR_DEF("_export_template_download_directory", ""));
 	install_file_dialog->add_filter("*.tpz", TTR("Godot Export Templates"));
-	install_file_dialog->connect("file_selected", callable_mp(this, &ExportTemplateManager::_install_file_selected).bind(false));
+	install_file_dialog->connect("file_selected", callable_mp(this, &ExportTemplateManager::_install_file_selected).bind(false), CONNECT_DEFERRED);
 	add_child(install_file_dialog);
 
 	hide_dialog_accept = memnew(AcceptDialog);


### PR DESCRIPTION
This fixes the empty dialog box when trying to install invalid export templates files.
The solution was gotten from [timothyqiu](https://github.com/timothyqiu) on the issue this pull fixes: https://github.com/godotengine/godot/issues/85862

Before the fix:
<img width="780" alt="image" src="https://github.com/user-attachments/assets/3ca365b0-afae-4310-b0ea-11263855a176">

After the fix:
<img width="773" alt="image" src="https://github.com/user-attachments/assets/e13727e1-d8f6-44ad-b6f9-56e65a1e3f79">

While nothing glamorous, this is my first PR. :D